### PR TITLE
Delete relationship test fix

### DIFF
--- a/RelationshipTest.py
+++ b/RelationshipTest.py
@@ -56,8 +56,10 @@ class RelationshipTest(unittest.TestCase):
         collection.addClass("foo")
         collection.addClass("bar")
         collection.addRelationship("foo", "bar")
+        collection.deleteRelationship("foo", "bar")
         self.assertNotIn(("foo", "bar"), collection.relationshipDict)
-
+        self.assertRaises(KeyError, collection.deleteRelationship, "foo", "bar")
+        
 if __name__ == '__main__':
     unittest.main()
     

--- a/RelationshipTest.py
+++ b/RelationshipTest.py
@@ -56,8 +56,7 @@ class RelationshipTest(unittest.TestCase):
         collection.addClass("foo")
         collection.addClass("bar")
         collection.addRelationship("foo", "bar")
-        self.assertRaises(KeyError, collection.deleteRelationship, "foo", "bar")
-        
+        self.assertIn(("foo", "bar"), collection.relationshipDict)
 if __name__ == '__main__':
     unittest.main()
     

--- a/RelationshipTest.py
+++ b/RelationshipTest.py
@@ -56,7 +56,8 @@ class RelationshipTest(unittest.TestCase):
         collection.addClass("foo")
         collection.addClass("bar")
         collection.addRelationship("foo", "bar")
-        self.assertIn(("foo", "bar"), collection.relationshipDict)
+        self.assertNotIn(("foo", "bar"), collection.relationshipDict)
+
 if __name__ == '__main__':
     unittest.main()
     


### PR DESCRIPTION
Forgot to call delete relationship before calling assertRaises. Also added extra assert for membership in dictionary.