### PR TITLE
Fixed crashes via empty line & one word prompts, updated help.txt

### DIFF
--- a/Help.txt
+++ b/Help.txt
@@ -2,7 +2,9 @@
 ------------------------------
 This program accepts user input to add, delete, display, and modify elements of a text representation of a UML diagram.
 
-This program accepts the following commands:
+This program accepts the following commands.
+Commands are case-insensitive. 
+Typing in an incomplete command will prompt the user for missing parameters.
 
 --------- Interface ---------
 Exit: Exits the application.
@@ -16,26 +18,76 @@ List Classes: Lists the contents of all classes within the current UML diagram.
 List Class: Asks for the name of the class in the current UML diagram and lists the contents of that class.
 
 --------- Save/Load ---------
-Save: Asks for the name of the file and saves the contents of the current UML diagram under that file name.
+Save: Asks for the name of the file and saves the contents of the current UML diagram under that file name. 
+If the name given is "foo", the file will be foo.monty.
 
-Load: Asks for the name of the file to load from and loads the contents of that file as the current UML diagram.
+Load: Asks for the name of the file to load from and loads the contents of that file as the current UML diagram. 
+If the name given is "foo", the file loaded will be foo.monty.
 
 --------- Classes ---------
 Add Class: Asks for the name of the new class and adds that class to the current UML diagram.
 
 Delete Class: Asks for the name of the class and deletes that class from the current UML diagram.
 
-Rename Class: Asks for the original name and new name of the class in the current UML diagram.  Changes the old name of the class to the new name.
+Rename Class: Asks for the original name and new name of the class in the current UML diagram.
+Changes the old name of the class to the new name.
 
 --------- Relationships ---------
-Add Relationship: Asks for a source and destination class in the current UML diagram. Adds a relationship between the two classes.
+Add Relationship: Asks for a source class and a destination class in the current UML diagram and a type of relationship. 
+Adds a relationship between the two classes with that type of relationship.
 
-Delete Relationship: Asks for a source and destination class in the current UML diagram and deletes their relationship if one exists.
+Delete Relationship: Asks for a source class and destination class in the current UML diagram and deletes their relationship if one exists.
 
---------- Attributes ---------
-Add Attribute: Asks for the name of the class in the UML diagram to add an attribute to, and the attribute name. Creates an attribute within that class.
+Rename Relationship: Asks for a source class and destination class in the current UML diagram and a type of relationship. 
+The type of the relationship between these two classes is then changed.
 
-Delete Attribute: Asks for the name of the class in the UML diagram that the attribute is in, and the name of the attribute. Deletes the attribute from the specified class. 
+--------- Methods ---------
+Add Method: Asks for the name of the class in the UML diagram to add a method to, the method's name, and its return type. 
+The user is then asked to supply any parameters for the method. 
+The format for adding parameters is alternating type and name, with type being the first word. Ex. int foo int bar. 
+The user may enter no parameters by sending an empty line. 
+NOTE: If an odd number of words are supplied (ex. int foo int bar str), then the final word is ignored.
 
-Rename Attribute: Asks for the class name, the old attribute name, and the new attribute name. Adds the attribute to the specified class in the current UML diagram.
+Delete Method: Asks for the name of the class in the UML diagram that the method is in, and the name of the method. 
+The user then must select which form of the method to delete. This then deletes the selected instance of the method.
+
+Rename Method: Asks for the name of the class in the UML diagram, the current name of the method, and the new name for the method. 
+The user then must select which form of the method to rename. This instance of the method is then given the new name.
+
+--------- Fields ---------
+Add Field: Asks for the name of the class in the UML diagram to add a field to, the field's name, and its type. 
+A field of this name and type is then added to the class.
+
+Delete Field: Asks for the name of the class in the UML diagram that the field is in, and the name of the field. 
+The field of this name is then removed from the class.
+
+Rename Field: Asks for the name of the class in the UML diagram that the field is in, the field's old name, and the field's new name. 
+The field of the old name is then renamed to the new name within the class.
+
+--------- Parameters ---------
+Add Parameter: Asks for the name of the class in the UML diagram and a method name within that class to add a parameter to. 
+The user then must select which form of the method to add a parameter to.
+The user is then asked to provide a type and a name for the new parameter.
+NOTE: User input past the first type and name are ignored.
+
+Remove Parameter: Asks for the name of the class in the UML diagram and a method name within that class to remove a parameter from. 
+The user then must select which form of the method to remove a parameter from.
+The user is then asked to provide the name of the parameter to remove.
+
+Remove Parameters: Asks for the name of the class in the UML diagram and a method name within that class to remove a parameter from. 
+The user then must select which form of the method to remove parameters from. 
+All parameters are removed from this instance of the method.
+
+Change Parameter: Asks for the name of the class in the UML diagram and a method name within that class to remove a parameter from. 
+The user then must select which form of the method to change a parameter of. 
+The user is then asked to provide the name of the parameter to change, the new type for the parameter, and the new name for the parameter. 
+The chosen parameter is then changed within this instance of the method.
+
+Change Parameters: Asks for the name of the class in the UML diagram and a method name within that class to remove a parameter from. 
+The user then must select which form of the method to change all parameters of. 
+The user is then asked to provide a list of parameters to replace the current list for this instance of the method. 
+The format for adding parameters is alternating type and name, with type being the first word. Ex. int foo int bar. 
+The user may enter no parameters by sending an empty line. 
+NOTE: If an odd number of words are supplied (ex. int foo int bar str), then the final word is ignored.
+
 ------------------------------

--- a/REPL.py
+++ b/REPL.py
@@ -40,17 +40,28 @@ response = ""
 response = input('What would you like to do? \nType "Help" for options.\n')
 tokens = response.split()
 
+if len(tokens) == 0:
+    tokens.append('')
+
 while (tokens[0].lower() != 'exit'):
     # Forms list of individual words of input
     # As some commands are one, some are two, .lower() is used only on the first
     # If a second word for a command is needed, .lower() is used after identifying
     # which form of command it is
     tokens = response.split()
+
+    if len(tokens) == 0:
+        tokens.append('')
+    
     tokens[0] = tokens[0].lower()
 
     try:
         # ------- Add ------- #
         if tokens[0] == 'add':
+            if len(tokens) == 1:
+                addedTokens = input('What would you like to add?\n').split()
+                tokens.extend(addedTokens)
+            
             obj = tokens[1].lower()
 
             # Add class takes one parameter: name
@@ -80,7 +91,7 @@ while (tokens[0].lower() != 'exit'):
                     addedTokens = requestParameters(paramList[start:])
                     tokens.extend(addedTokens)
                 # Adds relationship
-                collection.addRelationship(tokens[2], tokens[3], tokens[4])
+                collection.addRelationship(tokens[2], tokens[3], tokens[4].lower())
 
             # Add field takes three parameters: class name, field name, type
             if obj == 'field':
@@ -105,7 +116,7 @@ while (tokens[0].lower() != 'exit'):
                     start = len(paramList) - missing
                     addedTokens = requestParameters(paramList[start:])
                     tokens.extend(addedTokens)
-                params = input(f"Please list any parameters for the method {tokens[3]}.\nEx: int foo int bar\n")
+                params = input(f"Please list any parameters for the method {tokens[3]}. Ex: int foo int bar\nAn empty list of parameters can added by inputting an empty line.\nNote: if an odd number of words are provided, the final word is ignored\n")
                 paramsTokens = params.split()
                 methodParameters = []
                 for typ, name in zip(paramsTokens[0::2], paramsTokens[1::2]):
@@ -136,7 +147,7 @@ while (tokens[0].lower() != 'exit'):
                     methodNum = input(f"Please select a parameter list by its number.\n")
                     methodParameters = parametersLists[methodNum]
 
-                    paramRaw = input("Please input the parameter type and name to be added:\n")
+                    paramRaw = input("Please input the parameter type and name to be added.\nNote: additional words past the first type and name will be ignored.\n")
                     param = paramRaw.split()
 
                     if len(param) <= 1:
@@ -154,6 +165,10 @@ while (tokens[0].lower() != 'exit'):
 
         # ------- Delete ------- #
         elif tokens[0] == 'delete':
+            if len(tokens) == 1:
+                addedTokens = input('What would you like to delete?\n').split()
+                tokens.extend(addedTokens)
+            
             obj = tokens[1].lower()
 
             # Delete class takes one parameter: name
@@ -223,6 +238,10 @@ while (tokens[0].lower() != 'exit'):
 
         # ------- Rename ------- #
         elif tokens[0] == 'rename':
+            if len(tokens) == 1:
+                addedTokens = input('What would you like to rename?\n').split()
+                tokens.extend(addedTokens)
+            
             obj = tokens[1].lower()
 
             # Rename class takes two parameters: old name, new name
@@ -247,7 +266,7 @@ while (tokens[0].lower() != 'exit'):
                     addedTokens = requestParameters(paramList[start:])
                     tokens.extend(addedTokens)
                 # Renames class
-                collection.renameRelationship(tokens[2], tokens[3], tokens[4])
+                collection.renameRelationship(tokens[2], tokens[3], tokens[4].lower())
 
             # Rename field takes three parameters: class name, old field name, new field name
             if obj == 'field':
@@ -291,6 +310,10 @@ while (tokens[0].lower() != 'exit'):
 
         # ------- Remove ------- #
         elif tokens[0] == 'remove':
+            if len(tokens) == 1:
+                addedTokens = input('What would you like to remove?\n').split()
+                tokens.extend(addedTokens)
+            
             obj = tokens[1].lower()
 
             # Remove parameter takes two required parameters: class name, method name
@@ -352,6 +375,10 @@ while (tokens[0].lower() != 'exit'):
 
         # ------- Change ------- #
         elif tokens[0] == 'change':
+            if len(tokens) == 1:
+                addedTokens = input('What would you like to change?\n').split()
+                tokens.extend(addedTokens)
+            
             obj = tokens[1].lower()
 
             # Change parameter takes two required parameters: class name, method name
@@ -419,6 +446,10 @@ while (tokens[0].lower() != 'exit'):
 
         # ------- List ------- #
         elif tokens[0] == 'list':
+            if len(tokens) == 1:
+                addedTokens = input('What would you like to list?\n').split()
+                tokens.extend(addedTokens)
+            
             obj = tokens[1].lower()
 
             # List class takes one parameter: class name
@@ -492,6 +523,10 @@ while (tokens[0].lower() != 'exit'):
        # Exit takes zero parameters
         elif tokens[0] == 'exit':
             Interface.exit()
+
+        # ------- Blank ------- #
+        elif tokens[0] == '':
+            print('If you would like to see input options, please type "help".\n')
 
         else:
             print('Invalid input. \nIf you would like to see input options, please type "help".\n')


### PR DESCRIPTION
In addition to empty lines crashing the CLI, one word prompts for words that are understood by the interpreter, but are not full commands (such as just typing "add") would also crash the CLI.