### PR TITLE
Undo/Redo (CLI)

### DIFF
--- a/ActionStack.py
+++ b/ActionStack.py
@@ -1,0 +1,31 @@
+class ActionStack():
+    def __init__(self, Momento):
+        #Entries in the stacks are Momento objects
+        self.undoStack = []
+        self.redoStack = []
+        self.currentObj = Momento
+        self.originalObj = Momento
+
+
+    #Called when an undoable command (excluding undo/redo)
+    #is called. Clears the redo stack to avoid illegal calls
+    def add(self, Momento):
+        self.undoStack.append(self.currentObj)
+        self.currentObj = Momento
+        self.redoStack = []
+
+    #Called when undo is called. Appends to redo stack
+    def undoPop(self):
+        if len(self.undoStack) != 0:
+            self.redoStack.append(self.currentObj)
+            self.currentObj = self.undoStack.pop()
+        else:
+            self.currentState = self.originalState
+
+    #Called when redo is called. Appends to undo stack
+    def redoPop(self):
+        if len(self.redoStack) != 0:
+            self.undoStack.append(self.currentObj)
+            self.currentObj = self.redoStack.pop()
+            self.undoStack.append(self.currentObj)
+        

--- a/ActionStack.py
+++ b/ActionStack.py
@@ -4,6 +4,7 @@ class ActionStack():
         self.undoStack = []
         self.redoStack = []
         self.currentObj = Momento
+        self.originalObj = Momento
 
 
     #Called when an undoable command (excluding undo/redo)
@@ -15,11 +16,16 @@ class ActionStack():
 
     #Called when undo is called. Appends to redo stack
     def undoPop(self):
-        if len(self.undoStack) != 0:
-            self.redoStack.append(self.currentObj)
-            self.currentObj = self.undoStack.pop()
-        else:
+        self.redoStack.append(self.currentObj)
+        for each in self.undoStack:
+            print(each.state.classDict)
+        self.currentObj = self.undoStack.pop()
+        print(self.originalObj.state.classDict)
+
+        if len(self.undoStack) == 0:
             print("No actions to undo")
+            self.currentObj = self.originalObj
+            print(self.originalObj.state.classDict)
 
     #Called when redo is called. Appends to undo stack
     def redoPop(self):
@@ -34,3 +40,4 @@ class ActionStack():
         self.undoStack = []
         self.redoStack = []
         self.currentObj = Momento
+        self.originalObj = Momento

--- a/ActionStack.py
+++ b/ActionStack.py
@@ -4,7 +4,6 @@ class ActionStack():
         self.undoStack = []
         self.redoStack = []
         self.currentObj = Momento
-        self.originalObj = Momento
 
 
     #Called when an undoable command (excluding undo/redo)
@@ -20,7 +19,6 @@ class ActionStack():
             self.redoStack.append(self.currentObj)
             self.currentObj = self.undoStack.pop()
         else:
-            self.currentObj = self.originalObj
             print("No actions to undo")
 
     #Called when redo is called. Appends to undo stack
@@ -36,4 +34,3 @@ class ActionStack():
         self.undoStack = []
         self.redoStack = []
         self.currentObj = Momento
-        self.originalObj = Momento

--- a/ActionStack.py
+++ b/ActionStack.py
@@ -7,41 +7,31 @@ class ActionStack():
         self.redoStack = []
         self.currentObj = deepcopy(Momento)
         self.originalObj = deepcopy(Momento)
-        print("ORIGINAL OBJ INIT")
-        print(self.originalObj.state.classDict)
 
 
     #Called when an undoable command (excluding undo/redo)
     #is called. Clears the redo stack to avoid illegal calls
     def add(self, Momento):
         self.undoStack.append(self.currentObj)
-        print(self.currentObj.state.classDict)
-        print(self.originalObj.state.classDict)
         self.currentObj = deepcopy(Momento)
         self.redoStack = []
 
     #Called when undo is called. Appends to redo stack
     def undoPop(self):
-        self.redoStack.append(self.currentObj)
-        for each in self.undoStack:
-            print(each.state.classDict)
-        self.currentObj = self.undoStack.pop()
-        print(self.originalObj.state.classDict)
-
         if len(self.undoStack) == 0:
             print("No actions to undo")
             self.currentObj = deepcopy(self.originalObj)
-            print(self.originalObj.state.classDict)
+        else:   
+            self.redoStack.append(self.currentObj)
+            self.currentObj = deepcopy(self.undoStack.pop())
 
     #Called when redo is called. Appends to undo stack
     def redoPop(self):
-        if len(self.redoStack) != 0:
-            self.undoStack.append(self.currentObj)
-            for each in self.redoStack:
-                print(each.state.classDict)
-            self.currentObj = self.redoStack.pop()
-        else:
+        if len(self.redoStack) == 0:
             print("No actions to redo")
+        else:
+            self.undoStack.append(self.currentObj)
+            self.currentObj = deepcopy(self.redoStack.pop())
         
     def reset(self, Momento):
         self.undoStack = []

--- a/ActionStack.py
+++ b/ActionStack.py
@@ -12,7 +12,7 @@ class ActionStack():
     #Called when an undoable command (excluding undo/redo)
     #is called. Clears the redo stack to avoid illegal calls
     def add(self, Momento):
-        self.undoStack.append(self.currentObj)
+        self.undoStack.append(deepcopy(self.currentObj))
         self.currentObj = deepcopy(Momento)
         self.redoStack = []
 
@@ -22,15 +22,20 @@ class ActionStack():
             print("No actions to undo")
             self.currentObj = deepcopy(self.originalObj)
         else:   
-            self.redoStack.append(self.currentObj)
+            self.redoStack.append(deepcopy(self.currentObj))
             self.currentObj = deepcopy(self.undoStack.pop())
+
+            #Fringe case to fix being unable to remove a class added
+            #if added immediately after returning to the original state
+            if len(self.undoStack) == 0:
+                self.currentObj = deepcopy(self.originalObj)
 
     #Called when redo is called. Appends to undo stack
     def redoPop(self):
         if len(self.redoStack) == 0:
             print("No actions to redo")
         else:
-            self.undoStack.append(self.currentObj)
+            self.undoStack.append(deepcopy(self.currentObj))
             self.currentObj = deepcopy(self.redoStack.pop())
         
     def reset(self, Momento):

--- a/ActionStack.py
+++ b/ActionStack.py
@@ -21,6 +21,7 @@ class ActionStack():
             self.currentObj = self.undoStack.pop()
         else:
             self.currentObj = self.originalObj
+            print("No actions to undo")
 
     #Called when redo is called. Appends to undo stack
     def redoPop(self):
@@ -28,6 +29,8 @@ class ActionStack():
             self.undoStack.append(self.currentObj)
             self.currentObj = self.redoStack.pop()
             self.undoStack.append(self.currentObj)
+        else:
+            print("No actions to redo")
         
     def reset(self, Momento):
         self.undoStack = []

--- a/ActionStack.py
+++ b/ActionStack.py
@@ -1,17 +1,23 @@
+from copy import deepcopy
+
 class ActionStack():
     def __init__(self, Momento):
         #Entries in the stacks are Momento objects
         self.undoStack = []
         self.redoStack = []
-        self.currentObj = Momento
-        self.originalObj = Momento
+        self.currentObj = deepcopy(Momento)
+        self.originalObj = deepcopy(Momento)
+        print("ORIGINAL OBJ INIT")
+        print(self.originalObj.state.classDict)
 
 
     #Called when an undoable command (excluding undo/redo)
     #is called. Clears the redo stack to avoid illegal calls
     def add(self, Momento):
         self.undoStack.append(self.currentObj)
-        self.currentObj = Momento
+        print(self.currentObj.state.classDict)
+        print(self.originalObj.state.classDict)
+        self.currentObj = deepcopy(Momento)
         self.redoStack = []
 
     #Called when undo is called. Appends to redo stack
@@ -24,20 +30,21 @@ class ActionStack():
 
         if len(self.undoStack) == 0:
             print("No actions to undo")
-            self.currentObj = self.originalObj
+            self.currentObj = deepcopy(self.originalObj)
             print(self.originalObj.state.classDict)
 
     #Called when redo is called. Appends to undo stack
     def redoPop(self):
         if len(self.redoStack) != 0:
             self.undoStack.append(self.currentObj)
+            for each in self.redoStack:
+                print(each.state.classDict)
             self.currentObj = self.redoStack.pop()
-            self.undoStack.append(self.currentObj)
         else:
             print("No actions to redo")
         
     def reset(self, Momento):
         self.undoStack = []
         self.redoStack = []
-        self.currentObj = Momento
-        self.originalObj = Momento
+        self.currentObj = deepcopy(Momento)
+        self.originalObj = deepcopy(Momento)

--- a/ActionStack.py
+++ b/ActionStack.py
@@ -20,7 +20,7 @@ class ActionStack():
             self.redoStack.append(self.currentObj)
             self.currentObj = self.undoStack.pop()
         else:
-            self.currentState = self.originalState
+            self.currentObj = self.originalObj
 
     #Called when redo is called. Appends to undo stack
     def redoPop(self):
@@ -29,3 +29,8 @@ class ActionStack():
             self.currentObj = self.redoStack.pop()
             self.undoStack.append(self.currentObj)
         
+    def reset(self, Momento):
+        self.undoStack = []
+        self.redoStack = []
+        self.currentObj = Momento
+        self.originalObj = Momento

--- a/GUIController.py
+++ b/GUIController.py
@@ -4,6 +4,9 @@ import Interface
 from PopupBoxes import *
 import GUIMenuBar, MoveClass
 import traceback
+from Command import Command
+from Momento import Momento
+from ActionStack import ActionStack
 
 # A default collection
 collection = ClassCollection()
@@ -21,12 +24,15 @@ class GUIController:
 
         self.moveClass = MoveClass.MoveClass(self, self.view, self.view.canvas)
 
+        self.saveStates = ActionStack(Momento(Command("",""), self.model))
+
 
     def load(self, name):
         if self.debug:
             print(name)
         Interface.loadFile(self.model, name, "GUI", self.view)
          #self.view.drawLines()
+        self.saveStates.reset(Momento(Command("",""), self.model))
 
     def save(self, name):
         Interface.saveFile(self.model, name, "GUI", self.view)
@@ -64,6 +70,8 @@ class GUIController:
 
         if self.debug:
             print(self.model.classDict)
+
+        self.saveStates.add(Momento(Command("",""), self.model))
      
     def deleteClass(self, name):
         if name == '':
@@ -80,6 +88,8 @@ class GUIController:
             errorBox = self.windowFactory("alertBox", e)       
         if self.debug:
             print(self.model.classDict)
+
+        self.saveStates.add(Momento(Command("",""), self.model))
         
     def renameClass(self, oldName, newName):
         errorFlag = False
@@ -115,6 +125,8 @@ class GUIController:
         if self.debug:
             print(self.model.classDict)
 
+        self.saveStates.add(Momento(Command("",""), self.model))
+
     def addRelationship(self, firstClassName, secondClassName, typ):
         errorFlag = False
         errorString = ''
@@ -145,6 +157,8 @@ class GUIController:
         if self.debug:
             print(self.model.relationshipDict)
 
+        self.saveStates.add(Momento(Command("",""), self.model))
+
     def deleteRelationship(self, firstClassName, secondClassName):
         errorFlag = False
         errorString = ''
@@ -170,6 +184,8 @@ class GUIController:
             errorBox = self.windowFactory("alertBox", e)
         if self.debug:
             print(self.model.relationshipDict)
+
+        self.saveStates.add(Momento(Command("",""), self.model))
 
 
     def renameRelationship(self, firstClassName, secondClassName, typ):
@@ -200,6 +216,8 @@ class GUIController:
             errorBox = self.windowFactory("alertBox", e)
         if self.debug:
             print(self.model.relationshipDict)
+        
+        self.saveStates.add(Momento(Command("",""), self.model))
 
     def addMethod(self, className, methodName, returnType, parameters):
         try:
@@ -224,6 +242,8 @@ class GUIController:
         if self.debug:
             print(self.model.classDict)    
 
+        self.saveStates.add(Momento(Command("",""), self.model))
+
     def renameMethod(self, className, methodName, params, newName):
         try:
             self.model.renameMethod(className, methodName, params, newName)
@@ -234,6 +254,8 @@ class GUIController:
             errorBox = self.windowFactory("alertBox", e)
         if self.debug:
             print(self.model.classDict)
+
+        self.saveStates.add(Momento(Command("",""), self.model))
 
     def addParameter(self, className, methodName, params, typ, name):
         try:
@@ -246,6 +268,8 @@ class GUIController:
         if self.debug:
             print(self.model.classDict[className].methodDict)
 
+        self.saveStates.add(Momento(Command("",""), self.model))
+
     def removeParameter(self, className, methodName, params, name):
         try:
             self.model.removeParameter(className, methodName, params, name)
@@ -257,6 +281,8 @@ class GUIController:
         if self.debug:
             print(self.model.classDict)
 
+        self.saveStates.add(Momento(Command("",""), self.model))
+
     def changeParameter(self, className, methodName, params, name, newType, newName):
         try:
             self.model.changeParameter(className, methodName, params, name, newType, newName)
@@ -267,6 +293,8 @@ class GUIController:
             errorBox = self.windowFactory("alertBox", e)
         if self.debug:
             print(self.model.classDict)
+
+        self.saveStates.add(Momento(Command("",""), self.model))
 
     def addField(self, className, name, dataType):
         errorFlag = False
@@ -299,6 +327,8 @@ class GUIController:
         if self.debug:
             print(self.model.classDict)
 
+        self.saveStates.add(Momento(Command("",""), self.model))
+
     def deleteField(self, className, name):
         errorFlag = False
         errorString = ''
@@ -324,6 +354,8 @@ class GUIController:
             errorBox = self.windowFactory("alertBox", e)
         if self.debug:
             print(self.model.classDict)
+
+        self.saveStates.add(Momento(Command("",""), self.model))
 
     def renameField(self, className, oldName, newName):
         errorFlag = False
@@ -355,11 +387,17 @@ class GUIController:
         if self.debug:
             print(self.model.classDict)
 
+        self.saveStates.add(Momento(Command("",""), self.model))
+
     def undo(self):
-        pass
+        self.saveStates.undoPop()
+        self.model = self.saveStates.currentObj.state
+        self.refreshCanvas()
 
     def redo(self):
-        pass
+        self.saveStates.redoPop()
+        self.model = self.saveStates.currentObj.state
+        self.refreshCanvas()
     
     def listMethods(self, className, methodName, numbered=True):
         if className in self.model.classDict and methodName in self.model.getAllMethods(className):

--- a/Help.txt
+++ b/Help.txt
@@ -27,6 +27,19 @@ list_classes
 list_class <class>
     List contents of a single class
 
+undo
+    Undoes the last applicable action. Actions that cannot be undone include
+    exit, help, clear, list_relationships, list_classes, list_class, save,
+    load. Undo will search for the most recent command not in this list and
+    will revert the changes made by it.
+
+redo
+    Redoes the last applicable action. Actions that cannot be undone include
+    exit, help, clear, list_relationships, list_classes, list_class, save,
+    load. Redo will search for the most recently undone command not in this
+    list and will execute it again. The list of redo actions is reset when
+    a command that is not redo and not in the mentioned list is called.
+    
 --------------- Save/Load ---------------
 
 save <filename>

--- a/Help.txt
+++ b/Help.txt
@@ -38,7 +38,7 @@ redo
     exit, help, clear, list_relationships, list_classes, list_class, save,
     load. Redo will search for the most recently undone command not in this
     list and will execute it again. The list of redo actions is reset when
-    a command that is not redo and not in the mentioned list is called.
+    a command that is not undo, redo or in the mentioned list is called.
     
 --------------- Save/Load ---------------
 

--- a/Momento.py
+++ b/Momento.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 class Momento:
     def __init__(self, command, classCollection):
         self.command = command
-        self.classCollection = deepcopy(classCollection)
+        self.state = deepcopy(classCollection)
     def getState(self):
         return self.state
     def getCommand(self):

--- a/REPL.py
+++ b/REPL.py
@@ -7,6 +7,7 @@ from colorama import init, Fore
 from ClassCollection import ClassCollection
 from Command import Command
 from Momento import Momento
+from ActionStack import ActionStack
 import Interface
 
 if os.name == 'nt':
@@ -18,8 +19,8 @@ class MontyREPL(cmd.Cmd):
     def __init__(self, completekey='tab', stdin=None, stdout=None):
         super().__init__(completekey, stdin, stdout)
         init(autoreset=True)
-        self.saveStates = []
         self.model = ClassCollection()
+        self.saveStates = ActionStack(Momento(Command("",""), self.model))
         self.intro = (Fore.GREEN + '\nMontyPython UML Editor\n' + '='*80 + 
             '\nType help [verbose|<command-name>] or ? for help on commands.\n' + Fore.RESET)
 
@@ -115,6 +116,14 @@ class MontyREPL(cmd.Cmd):
         else:
             self.help_load()
 
+    def do_undo(self, args):
+        self.saveStates.undoPop()
+        self.model = self.saveStates.currentObj.state
+
+    def do_redo(self, args):
+        self.saveStates.redoPop()
+        self.model = self.saveStates.currentObj.state
+
     # Classes
     def do_add_class(self, args):
         self.execute(self.model.addClass, args)
@@ -209,6 +218,10 @@ class MontyREPL(cmd.Cmd):
         self.print_cmd_help('save')
     def help_load(self):
         self.print_cmd_help('load')
+    def help_undo(self):
+        self.print_cmd_help('undo')
+    def help_redo(self):
+        self.print_cmd_help('redo')
 
     def help_add_class(self):
         self.print_cmd_help('add_class')
@@ -416,7 +429,14 @@ class MontyREPL(cmd.Cmd):
             args = args.split()
         command = Command(function, *args)
         command.execute()
-        self.saveStates.append(Momento(command, self.model))
+
+        #List of commands which cannot be undone or redone, as well as undo and redo
+        #Undo and redo are handled specially within their do functions
+        unusuals = ["help", "clear", "save", "load", "undo", "redo", "list_class", "list_classes", "list_relationships"]
+        if command.function not in unusuals:
+            self.saveStates.add(Momento(command, self.model))
+
+
     
     def onecmd(self, line):
         try:

--- a/REPL.py
+++ b/REPL.py
@@ -113,6 +113,7 @@ class MontyREPL(cmd.Cmd):
     def do_load(self, args):
         if len(args) > 0:
             Interface.loadFile(self.model, args)
+            self.saveStates.reset(Momento(Command("",""), self.model))
         else:
             self.help_load()
 
@@ -430,11 +431,10 @@ class MontyREPL(cmd.Cmd):
         command = Command(function, *args)
         command.execute()
 
-        #List of commands which cannot be undone or redone, as well as undo and redo
-        #Undo and redo are handled specially within their do functions
-        unusuals = ["help", "clear", "save", "load", "undo", "redo", "list_class", "list_classes", "list_relationships"]
-        if command.function not in unusuals:
-            self.saveStates.add(Momento(command, self.model))
+        #Prior version had a list of commands to check against
+        #Which A) didn't work as intended and B) would be redundant
+        #as excluded functions already weren't added.
+        self.saveStates.add(Momento(command, self.model))
 
 
     

--- a/Tests/REPLTest.py
+++ b/Tests/REPLTest.py
@@ -58,4 +58,91 @@ class REPLTest(unittest.TestCase):
         repl = MontyREPL()
         repl.do_add_class('A')
         repl.do_add_class('B')
-        self.assertEqual(len(repl.saveStates), 2)
+        self.assertEqual(len(repl.saveStates.undoStack), 2)
+
+    def testUndo(self):
+        repl = MontyREPL()
+
+        #undo an add command
+        undoAddStrTest = "foo"
+        repl.do_add_class("foo")
+        repl.do_add_class("bar")
+        repl.do_undo("")
+        undoAddStr = ""
+        for each in repl.model.classDict.keys():
+            undoAddStr += each
+        self.assertTrue(undoAddStrTest == undoAddStr)
+
+        #undo a delete command
+        undoDelStrTest = "('foo', 'bar')"
+        repl.do_add_class("bar")
+        repl.do_add_class("fizz")
+        repl.do_add_relationship("foo bar aggregation")
+        repl.do_add_relationship("foo fizz aggregation")
+        repl.do_undo("")
+        undoDelStr = ""
+        for each in repl.model.relationshipDict.keys():
+            undoDelStr += str(each)
+        self.assertTrue(undoDelStrTest == undoDelStr)
+
+        #undo a rename command
+        undoRenStrTest = "('foo', 'test')"
+        repl.do_rename_class("bar test")
+        undoRenStr = ""
+        for each in repl.model.relationshipDict.keys():
+            undoRenStr += str(each)
+        self.assertTrue(undoRenStrTest == undoRenStr)
+
+        #undo when the most recent command cannot be undone
+        #clears classes as order matters and this is not guaranteed
+        #to add renamed classes to the end in the future
+        repl.do_delete_class("foo")
+        repl.do_delete_class("test")
+        repl.do_delete_class("fizz")
+        repl.do_add_class("foo")
+        repl.do_add_class("bar")
+        undoSkipStrTest = "foobar"
+        repl.do_add_class("removed")
+        repl.do_help("")
+        repl.do_undo("")
+        undoSkipStr = ""
+        for each in repl.model.classDict.keys():
+            undoSkipStr += each
+        self.assertTrue(undoSkipStrTest == undoSkipStr)
+
+    def testRedo(self):
+        repl = MontyREPL()
+
+        repl.do_add_class("foo")
+        repl.do_add_class("bar")
+        redoAddStrTest = ""
+        for each in repl.model.classDict.keys():
+            redoAddStrTest += each
+        repl.do_undo("")
+        repl.do_redo("")
+        redoAddStr = ""
+        for each in repl.model.classDict.keys():
+            redoAddStr += each
+        self.assertTrue(redoAddStrTest == redoAddStr)
+
+        repl.do_delete_class("foo")
+        redoDelStrTest = ""
+        for each in repl.model.classDict.keys():
+            redoDelStrTest += each
+        repl.do_undo("")
+        repl.do_redo("")
+        redoDelStr = ""
+        for each in repl.model.classDict.keys():
+            redoDelStr += each
+        self.assertTrue(redoDelStrTest == redoDelStr)
+
+        repl.do_rename_class("bar fizz")
+        redoRenStrTest = ""
+        for each in repl.model.classDict.keys():
+            redoRenStrTest += each
+        repl.do_undo("")
+        repl.do_redo("")
+        redoRenStr = ""
+        for each in repl.model.classDict.keys():
+            redoRenStr += each
+        self.assertTrue(redoRenStrTest == redoRenStr)


### PR DESCRIPTION
- "undo" and "redo" commands in CLI
- ActionStack object holds a stack of Momento objects for undo and another stack for redo
- Undo adds the undone action to the redo stack
- Redo adds the redone action to the undo stack
- Load clears both stacks
- Any other action which changes the model clears only the redo stack
- Help texts for both undo and redo
- Warning texts when the user attempts to undo or redo with an empty stack
- "quick and dirty" undo/redo setup in GUI to serve as a mockup
